### PR TITLE
fix: add snippets in note scripts to ensure account storage changes

### DIFF
--- a/lib/contracts/notes/game/inter_unmask.masm
+++ b/lib/contracts/notes/game/inter_unmask.masm
@@ -12,6 +12,13 @@ const.NO_OF_CARDS=3
 const.REQUESTER_INFO_SLOT=102
 const.TEMP_CARD_SLOT=103
 
+proc.note_state_change
+    push.254 exec.account::get_item
+    add.1
+    push.254 exec.account::set_item
+    dropw dropw
+end
+
 proc.inter_unmask
     # => [card_index, ca', cb']
     swap push.G inv
@@ -76,4 +83,6 @@ begin
     call.set_requester_data
 
     dropw dropw
+
+    call.note_state_change dropw
 end

--- a/lib/contracts/notes/game/send_community_cards.masm
+++ b/lib/contracts/notes/game/send_community_cards.masm
@@ -8,6 +8,13 @@ const.TEMP_CARD_SLOT=103
 const.PLAYER_DATA_SLOT=56
 const.PHASE_DATA_SLOT=57
 
+proc.note_state_change
+    push.254 exec.account::get_item
+    add.1
+    push.254 exec.account::set_item
+    dropw dropw
+end
+
 proc.receive_cards
     exec.account::set_item
     # => [R, V]
@@ -57,4 +64,6 @@ begin
     call.set_phase
 
     dropw dropw
+
+    call.note_state_change dropw
 end

--- a/lib/contracts/notes/game/send_unmasked_cards.masm
+++ b/lib/contracts/notes/game/send_unmasked_cards.masm
@@ -7,6 +7,13 @@ const.NO_OF_CARDS=3
 const.TEMP_CARD_SLOT=103
 const.PLAYER_DATA_SLOT=56
 
+proc.note_state_change
+    push.254 exec.account::get_item
+    add.1
+    push.254 exec.account::set_item
+    dropw dropw
+end
+
 proc.receive_cards
     exec.account::set_item
     # => [R, V]
@@ -57,4 +64,6 @@ begin
     call.increment_action_type
 
     dropw dropw
+
+    call.note_state_change dropw
 end

--- a/lib/contracts/notes/game/set_community_cards.masm
+++ b/lib/contracts/notes/game/set_community_cards.masm
@@ -5,6 +5,13 @@ use.miden::contracts::wallets::basic->wallet
 
 const.NO_OF_CARDS=3
 
+proc.note_state_change
+    push.254 exec.account::get_item
+    add.1
+    push.254 exec.account::set_item
+    dropw dropw
+end
+
 proc.set_cards
     # => [card_index, Cb, Ca]
     push.0 dup movup.2
@@ -46,6 +53,8 @@ begin
         loc_load.0 push.1 add
         loc_store.0
     end
+
+    call.note_state_change dropw
 
     dropw
 end


### PR DESCRIPTION
This is a quick fix that ensures the notes used in `unask_community_cards` always end up modifying the account's storage. This is a requirement because the current tx script that consumes notes increments the nonce and when doing so either the account storage should change or the account's vault should change.